### PR TITLE
Skips some validation for draft projects

### DIFF
--- a/app/assets/scripts/components/ProjectForm.js
+++ b/app/assets/scripts/components/ProjectForm.js
@@ -23,7 +23,7 @@ export const schema = {
     published: {
       title: 'Visibility',
       type: 'boolean',
-      defaut: 'Draft',
+      default: false,
       enumNames: ['Published', 'Draft']
     },
     private: {
@@ -441,16 +441,16 @@ class ProjectForm extends React.Component {
   }
 
   onChange ({formData}) {
+    let schema = cloneDeep(this.state.schema);
     if (formData.components) {
       const componentEnums = formData.components.filter((component) => {
         return component && component.component && component.component.length > 0;
       }).map((component) => `${component.component} - ${component.component_ar}`);
       if (componentEnums.length > 0) {
-        let schema = cloneDeep(this.state.schema);
         schema.properties.kmi.items.properties.component.enum = componentEnums;
-        this.setState({schema: schema, formData: formData});
       }
     }
+    this.setState({schema: schema, formData: formData});
   }
 
   onError (errors) {
@@ -460,12 +460,16 @@ class ProjectForm extends React.Component {
   }
 
   render () {
+    let isDraft = true;
+    if (this.state.formData && this.state.formData.published) {
+      isDraft = !this.state.formData.published;
+    }
     return <Form schema={this.state.schema}
       onSubmit={this.props.onSubmit}
       formData={this.state.formData}
       onChange = {this.onChange.bind(this)}
       onError= {this.onError.bind(this)}
-      noValidate={((this.state.formData.published === 'Draft') ? 'true' : 'false')}
+      noValidate={isDraft}
       fields={{
         'short-date': DateFieldFactory('Year', 'Month'),
         'fund-date': DateFieldFactory('Year Disbursed', 'Month Disbursed'),

--- a/app/assets/scripts/components/ProjectForm.js
+++ b/app/assets/scripts/components/ProjectForm.js
@@ -23,6 +23,7 @@ export const schema = {
     published: {
       title: 'Visibility',
       type: 'boolean',
+      defaut: 'Draft',
       enumNames: ['Published', 'Draft']
     },
     private: {
@@ -464,6 +465,7 @@ class ProjectForm extends React.Component {
       formData={this.state.formData}
       onChange = {this.onChange.bind(this)}
       onError= {this.onError.bind(this)}
+      noValidate={((this.state.formData.published === 'Draft') ? 'true' : 'false')}
       fields={{
         'short-date': DateFieldFactory('Year', 'Month'),
         'fund-date': DateFieldFactory('Year Disbursed', 'Month Disbursed'),


### PR DESCRIPTION
This skips some validation for draft projects, allowing the project
to be saved if the data is not entirely entered into the platform.

There are some fields (such as Project Name) where the HTM5 validation
captures the input:
 - Pros: this prevents a project to be saved without a name
 - Cons: could be annoying in the case of certain fields (such as
 entering a budget without knowing the donor name)

@felskia to test if this is a good enough draft system
Closes https://github.com/developmentseed/ifpri-egypt/issues/45