### PR TITLE
Indicator type is a checkbox

### DIFF
--- a/app/assets/scripts/components/IndicatorForm.js
+++ b/app/assets/scripts/components/IndicatorForm.js
@@ -41,15 +41,23 @@ export const schema = {
         'Environment'
       ]
     },
-    type: {
+    indicator_type: {
       title: 'Type of Indicator - نوع المؤشر',
-      type: 'string',
-      enum: [
-        'Select an Indicator',
-        'SDS Indicator - مؤشرات استراتيجية التنمية المُستدامة',
-        'SDG Indicator - مؤشرات أهداف التنمية المُستدامة',
-        'Other Development Indicator - مؤشرات إنمائية أخرى'
-      ]
+      type: 'object',
+      properties: {
+        sds: {
+          title: 'SDS Indicator - مؤشرات استراتيجية التنمية المُستدامة',
+          type: 'boolean'
+        },
+        sdg: {
+          title: 'SDG Indicator - مؤشرات أهداف التنمية المُستدامة',
+          type: 'boolean'
+        },
+        other: {
+          title: 'Other Development Indicator - مؤشرات إنمائية أخرى',
+          type: 'boolean'
+        }
+      }
     },
     sources: {
       type: 'array',
@@ -87,6 +95,9 @@ const uiSchema = {
   description_ar: {
     classNames: 'ar',
     'ui:widget': 'textarea'
+  },
+  indicator_type: {
+    classNames: 'indicator-checkbox'
   },
   category: {
     'ui:field': 'datatype'

--- a/app/assets/styles/_base.scss
+++ b/app/assets/styles/_base.scss
@@ -368,3 +368,14 @@ label {
     margin-bottom: .5em;
   }
 }
+
+.indicator-checkbox {
+  input[type="checkbox"] {
+    margin: 1em;
+    display: inline;
+  }
+
+  .field-boolean {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
Turns the indicator type into a checkbox cc @felskia 

Because I had to change the type of the indicator, I had to rename the property from `type` to `indicator_type` which is an object with 3 boolean properties `sds`, `sdg` and `other`. This will affect the API. cc @derek