### PR TITLE
Use typeof to differentiate array and string

### DIFF
--- a/app/assets/scripts/components/EditIndicator.js
+++ b/app/assets/scripts/components/EditIndicator.js
@@ -29,7 +29,7 @@ class EditIndicator extends React.Component {
     component.props.auth.request(`${apiRoot}/indicators/${id}`, 'get')
       .then(function (resp) {
         const indicator = resp;
-        if (indicator.data && indicator.data.data && !indicator.data.data.match(/^\w+\.\w+$/)) {
+        if (indicator.data && indicator.data.data && typeof indicator.data.data !== 'string') {
           indicator.data.data = jsonToCSV(indicator.data.data);
         }
         component.setState({ indicator, id });

--- a/app/assets/scripts/components/Indicator.js
+++ b/app/assets/scripts/components/Indicator.js
@@ -55,7 +55,7 @@ class Indicator extends React.Component {
         if (key === 'data' && indicator[key]) {
           // accept mapbox ids or csv
           let displayData;
-          if (indicator[key].match(/^\w+\.\w+$/)) {
+          if (typeof indicator[key] === 'string') {
             displayData = indicator[key];
           } else {
             displayData = jsonToCSV(indicator[key]);


### PR DESCRIPTION
For post meeting; this prevents editing of non mapbox-url based indicator data from failing to load cc: @felskia @kamicut 